### PR TITLE
fix: Add broken auto-generated types

### DIFF
--- a/definitions.json
+++ b/definitions.json
@@ -15,6 +15,11 @@
                         "Token": "TokenSymbol" 
                     }
                 },
+                "InterbtcPrimitivesCurrencyId": {
+                    "_enum": { 
+                        "Token": "InterbtcPrimitivesTokenSymbol" 
+                    }
+                },
                 "FundAccountJsonRpcRequest": {
                     "account_id": "AccountId",
                     "currency_id": "InterbtcPrimitivesCurrencyId"
@@ -22,6 +27,16 @@
                 "H256Le": "H256",
                 "SignedFixedPoint": "FixedU128",
                 "TokenSymbol": {
+                    "_enum": {
+                        "DOT": 0,
+                        "INTERBTC": 1, 
+                        "INTR": 2, 
+                        "KSM": 10, 
+                        "KBTC": 11, 
+                        "KINT": 12
+                    }
+                },
+                "InterbtcPrimitivesTokenSymbol": {
                     "_enum": {
                         "DOT": 0,
                         "INTERBTC": 1, 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@interlay/interbtc-types",
-    "version": "1.3.0",
+    "version": "1.5.10",
     "description": "Substrate types used in InterBTC parachain",
     "main": "build/index.js",
     "typings": "index.d.ts",


### PR DESCRIPTION
Types such as `InterbtcPrimitivesTokenSymbol` fail to be resolved in `interbtc-api`, which means their definition needs to be explicitly declared here too