### PR TITLE
Feat: add rewards estimate rpcs

### DIFF
--- a/definitions.json
+++ b/definitions.json
@@ -319,6 +319,42 @@
             }
         },
         "reward": {
+            "estimateEscrowRewardRate": {
+                "description": "Estimate the escrow reward rate for a given account",
+                "params": [
+                    {
+                        "name": "account_id",
+                        "type": "AccountId"
+                    },
+                    {
+                        "name": "amount",
+                        "type": "Option<Balance>"
+                    },
+                    {
+                        "name": "lock_time",
+                        "type": "Option<BlockNumber>"
+                    },
+                    {
+                        "name": "at",
+                        "type": "Option<BlockHash>"
+                    }
+                ],
+                "type": "UnsignedFixedPoint"
+            },
+            "estimateVaultRewardRate": {
+                "description": "Estimate the vault reward rate a given vault id",
+                "params": [
+                    {
+                        "name": "vault_id",
+                        "type": "VaultId"
+                    },
+                    {
+                        "name": "at",
+                        "type": "Option<BlockHash>"
+                    }
+                ],
+                "type": "UnsignedFixedPoint"
+            },
             "computeEscrowReward": {
                 "description": "Get a given user's rewards due",
                 "params": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@interlay/interbtc-types",
-    "version": "1.11.0",
+    "version": "1.11.1",
     "description": "Substrate types used in InterBTC parachain",
     "main": "build/index.js",
     "typings": "index.d.ts",


### PR DESCRIPTION
Two new rpc definitions for parachain v `1.21.1`:
`reward_estimateEscrowRewardRate`
`reward_estimateVaultRewardRate`

See definitions here: https://github.com/interlay/interbtc/blob/042085bc8def193657e55bb98021da7f14b2276d/crates/reward/rpc/src/lib.rs#L48-L58