### PR TITLE
fix(loans): rpc return type

### DIFF
--- a/definitions.json
+++ b/definitions.json
@@ -143,7 +143,7 @@
                         "isOptional": true
                     }
                 ],
-                "type": "(Liquidity, Shortfall, Liquidity, Shortfall)",
+                "type": "(Liquidity, Shortfall)",
                 "isSubscription": false,
                 "jsonrpc": "loans_getCollateralLiquidity",
                 "method": "getCollateralLiquidity",
@@ -163,7 +163,7 @@
                         "isOptional": true
                     }
                 ],
-                "type": "(Liquidity, Shortfall, Liquidity, Shortfall)",
+                "type": "(Liquidity, Shortfall)",
                 "isSubscription": false,
                 "jsonrpc": "loans_getLiquidationThresholdLiquidity",
                 "method": "getLiquidationThresholdLiquidity",


### PR DESCRIPTION
Updating to match the return types for `get_account_liquidity` and `get_liquidation_threshold_liquidity` of the parachain rpc [implementation](https://github.com/interlay/interbtc/blob/16980d8f5a392b85f9d82e35ba9562867612c935/crates/loans/rpc/src/lib.rs#L39).